### PR TITLE
Add geometry column to threshold data

### DIFF
--- a/databricks/flood-api-examples.py
+++ b/databricks/flood-api-examples.py
@@ -234,4 +234,20 @@ neighbors_only_df
 
 # COMMAND ----------
 
+# MAGIC %md
+# MAGIC
+# MAGIC **Open and query the threshold data**
 
+# COMMAND ----------
+
+threshold_df_file_path = os.path.join(PYTHON_PREFIX, S3_GLOFAS_AUX_DATA_PATH, GLOFAS_PROCESSED_THRESH_FILENAME)
+
+df_thresh = read_with_geopandas(threshold_df_file_path)
+
+# COMMAND ----------
+
+primary_cell_df_thresh = df_thresh[df_thresh['geometry'].intersects(reduced_geometry)]
+
+# COMMAND ----------
+
+primary_cell_df_thresh

--- a/databricks/threshold-data-joining.py
+++ b/databricks/threshold-data-joining.py
@@ -17,6 +17,7 @@
 
 import os
 from flood.utils.config import get_config_val
+from flood.spark.transforms import add_geometry
 from pyspark.sql import functions as F
 
 # COMMAND ----------
@@ -55,6 +56,7 @@ S3_GLOFAS_AUX_DATA_PATH = get_config_val("S3_GLOFAS_AUX_DATA_PATH")
 GLOFAS_RET_PRD_THRESH_PARQUET_FILENAMES = get_config_val("GLOFAS_RET_PRD_THRESH_PARQUET_FILENAMES")
 GLOFAS_RET_PRD_THRESH_VALS = get_config_val("GLOFAS_RET_PRD_THRESH_VALS")
 GLOFAS_PRECISION = get_config_val("GLOFAS_PRECISION")
+GLOFAS_RESOLUTION = get_config_val('GLOFAS_RESOLUTION')
 GLOFAS_PROCESSED_THRESH_FILENAME = get_config_val("GLOFAS_PROCESSED_THRESH_FILENAME")
 
 # COMMAND ----------
@@ -97,6 +99,16 @@ for next_df in dataframes[1:]:
 # Check if the count after joining is still the same
 combined_row_count = combined_df.count()
 assert combined_row_count == original_count, f"The count after joining ({combined_row_count}) is not the same as before ({original_count})."
+
+# COMMAND ----------
+
+# MAGIC %md
+# MAGIC
+# MAGIC **Add geometry column to easily load parquet file in GeoPandas**
+
+# COMMAND ----------
+
+combined_df = add_geometry(combined_df, GLOFAS_RESOLUTION / 2, GLOFAS_PRECISION)
 
 # COMMAND ----------
 

--- a/flood/spark/transforms.py
+++ b/flood/spark/transforms.py
@@ -161,9 +161,9 @@ def add_geometry(df, half_grid_size, precision):
     :return: The DataFrame with a geometry column.
     """
     return df.withColumn("min_latitude", F.round(F.col("latitude") - half_grid_size, precision))\
-             .withColumn("max_latitude", F.round(F.col("latitude") - half_grid_size, precision))\
-             .withColumn("min_longitude", F.round(F.col("latitude") - half_grid_size, precision))\
-             .withColumn("max_longitude", F.round(F.col("latitude") - half_grid_size, precision))\
+             .withColumn("max_latitude", F.round(F.col("latitude") + half_grid_size, precision))\
+             .withColumn("min_longitude", F.round(F.col("longitude") - half_grid_size, precision))\
+             .withColumn("max_longitude", F.round(F.col("longitude") + half_grid_size, precision))\
              .withColumn("wkt",\
                  F.concat(F.lit("POLYGON (("),\
                      F.col("min_longitude"), F.lit(" "), F.col("min_latitude"), F.lit(","),\


### PR DESCRIPTION
Fixes typos in the `add_geometry` function and applies it to the threshold data to allow efficient querying with GeoPandas. Includes a test of the `add_geometry` function.